### PR TITLE
3.0.0

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "npm-package-json-lint-config-tc",
   "rules": {
-    "prefer-no-version-zero-devDependencies": ["error", {"exceptions": ["eslint-plugin-vue-a11y"]}]
+    "prefer-no-version-zero-devDependencies": ["error", {"exceptions": ["eslint-plugin-vue-a11y"]}],
+    "valid-values-engines": "off"
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ### Node
 
-* [Node.js](https://nodejs.org/) - v8.0.0+
+* [Node.js](https://nodejs.org/) - v10.0.0+
 * [npm](https://www.npmjs.com/) - v6.0.0+
 
 ## Install project dependencies

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ First thing first, let's make sure you have the necessary pre-requisites.
 
 #### Node
 
-* [Node.js](https://nodejs.org/) - v8.0.0+
+* [Node.js](https://nodejs.org/) - v10.0.0+
 * [npm](http://npmjs.com) - v6.0.0+
 
 ### Command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vue-tc",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vue-tc",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "ESLint shareable config for Vue projects",
   "keywords": [
     "eslintconfig",
@@ -57,7 +57,7 @@
     "eslint-plugin-vue-a11y": "^0.0.31"
   },
   "engines": {
-    "node": ">=8.0.0",
+    "node": ">=10.0.0",
     "npm": ">=6.0.0"
   },
   "license": "MIT"

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -25,6 +25,7 @@ module.exports = {
     'vue/max-attributes-per-line': 'off',
     'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/no-boolean-default': 'error',
+    'vue/no-deprecated-slot-attribute': 'error',
     'vue/no-empty-pattern': 'error',
     'vue/require-direct-export': 'error',
     'vue/valid-v-slot': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -14,6 +14,7 @@ module.exports = {
         math: 'always'
       }
     ],
+    'vue/keyword-spacing': 'error',
     'vue/match-component-file-name': [
       'error',
       {

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -31,6 +31,7 @@ module.exports = {
     'vue/no-reserved-component-names': 'error',
     'vue/padding-line-between-blocks': 'error',
     'vue/require-direct-export': 'error',
+    'vue/require-name-property': 'error',
     'vue/valid-v-slot': 'error',
     'vue/v-slot-style': 'error'
   }

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -27,6 +27,7 @@ module.exports = {
     'vue/no-boolean-default': 'error',
     'vue/no-empty-pattern': 'error',
     'vue/require-direct-export': 'error',
+    'vue/valid-v-slot': 'error',
     'vue/v-slot-style': 'error'
   }
 };

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -1,19 +1,6 @@
 module.exports = {
   rules: {
-    'vue/max-attributes-per-line': 'off',
-    'vue/require-direct-export': 'error',
-    'vue/no-empty-pattern': 'off',
-    // 'vue/no-deprecated-scope-attribute': 'error',
-    'vue/no-boolean-default': 'error',
-    'vue/match-component-file-name': [
-      'error',
-      {
-        extensions: ['jsx'],
-        shouldMatchCase: false
-      }
-    ],
     'vue/component-name-in-template-casing': ['error', 'kebab-case'],
-    'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/html-self-closing': [
       'warn',
       {
@@ -25,6 +12,18 @@ module.exports = {
         svg: 'always',
         math: 'always'
       }
-    ]
+    ],
+    'vue/match-component-file-name': [
+      'error',
+      {
+        extensions: ['jsx'],
+        shouldMatchCase: false
+      }
+    ],
+    'vue/max-attributes-per-line': 'off',
+    'vue/name-property-casing': ['error', 'kebab-case'],
+    'vue/no-boolean-default': 'error',
+    'vue/no-empty-pattern': 'error',
+    'vue/require-direct-export': 'error'
   }
 };

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -26,6 +26,7 @@ module.exports = {
     'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/no-boolean-default': 'error',
     'vue/no-empty-pattern': 'error',
-    'vue/require-direct-export': 'error'
+    'vue/require-direct-export': 'error',
+    'vue/v-slot-style': 'error'
   }
 };

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -28,6 +28,7 @@ module.exports = {
     'vue/no-deprecated-slot-attribute': 'error',
     'vue/no-deprecated-slot-scope-attribute': 'error',
     'vue/no-empty-pattern': 'error',
+    'vue/no-reserved-component-names': 'error',
     'vue/require-direct-export': 'error',
     'vue/valid-v-slot': 'error',
     'vue/v-slot-style': 'error'

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -28,6 +28,7 @@ module.exports = {
     'vue/no-deprecated-slot-attribute': 'error',
     'vue/no-deprecated-slot-scope-attribute': 'error',
     'vue/no-empty-pattern': 'error',
+    'vue/no-irregular-whitespace': 'error',
     'vue/no-reserved-component-names': 'error',
     'vue/padding-line-between-blocks': 'error',
     'vue/require-direct-export': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -26,6 +26,7 @@ module.exports = {
     'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/no-boolean-default': 'error',
     'vue/no-deprecated-slot-attribute': 'error',
+    'vue/no-deprecated-slot-scope-attribute': 'error',
     'vue/no-empty-pattern': 'error',
     'vue/require-direct-export': 'error',
     'vue/valid-v-slot': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -29,6 +29,7 @@ module.exports = {
     'vue/no-deprecated-slot-scope-attribute': 'error',
     'vue/no-empty-pattern': 'error',
     'vue/no-reserved-component-names': 'error',
+    'vue/padding-line-between-blocks': 'error',
     'vue/require-direct-export': 'error',
     'vue/valid-v-slot': 'error',
     'vue/v-slot-style': 'error'

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+    'vue/dot-location': 'error',
     'vue/html-self-closing': [
       'warn',
       {


### PR DESCRIPTION
- Drop support for Node 8 and 9
- Add vue/no-empty-pattern - Closes #45
- Add vue/dot-location - Closes #44
- Add vue/v-slot-style - Closes #43 Closes #42
- Add vue/valid-v-slot  - Closes #41
- Add vue/no-deprecated-slot-attribute
- Add vue/no-deprecated-slot-scope-attribute
- Add vue/no-reserved-component-names
- Add vue/padding-line-between-blocks
- Add vue/require-name-property
- Add vue/no-irregular-whitespace