### PR TITLE
4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,10 @@ const vuex = require.resolve('./rules/vuex');
 module.exports = {
   extends: ['plugin:vue/recommended', a11y, vue, vuex],
   parserOptions: {
-    parser: 'babel-eslint'
+    parser: 'babel-eslint',
   },
   plugins: ['vue', 'vue-a11y'],
   env: {
-    es6: true
-  }
+    es6: true,
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vue-tc",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2604,33 +2604,33 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
-      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
+      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.7",
+        "confusing-browser-globals": "^1.0.9",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-tc": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-11.0.0.tgz",
-      "integrity": "sha512-gDr4euVY5PUx2KrEhEUJtSWbO2GiKIKMK8PEkBi3dlJg4qWWSiTYEy1J3N7apbaCdUSoXEOn6QdOQkNWP/wW4w==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-tc/-/eslint-config-tc-12.0.0.tgz",
+      "integrity": "sha512-ck02dII7fZj4ZDPp+hbD/j9mR83i6kCMzaxDvkfvUs1YlSW+3eY917sOS2DuOy8gnGp7K3aeHB60dhT11m6ScA==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.0.0",
-        "eslint-config-prettier": "^6.10.0"
+        "eslint-config-airbnb-base": "^14.1.0",
+        "eslint-config-prettier": "^6.10.1"
       }
     },
     "eslint-formatter-pretty": {
@@ -6300,9 +6300,9 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.4",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-          "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
@@ -6633,9 +6633,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
+      "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-vue-tc",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "ESLint shareable config for Vue projects",
   "keywords": [
     "eslintconfig",
@@ -36,20 +36,20 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
-    "eslint": "^6.7.2",
-    "eslint-config-tc": "^11.0.0",
+    "eslint": "^6.8.0",
+    "eslint-config-tc": "^12.0.0",
     "eslint-formatter-pretty": "^3.0.1",
     "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-jest": "^23.8.2",
-    "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-vue": "^6.2.2",
     "eslint-plugin-vue-a11y": "^0.0.31",
     "is-plain-obj": "^2.1.0",
     "jest": "^25.3.0",
     "npm-package-json-lint": "^4.6.0",
     "npm-package-json-lint-config-tc": "^3.0.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.4"
   },
   "peerDependencies": {
     "eslint": "^6.0.0",

--- a/rules/a11y.js
+++ b/rules/a11y.js
@@ -6,8 +6,8 @@ module.exports = {
     'vue-a11y/aria-role': [
       2,
       {
-        ignoreNonDOM: true
-      }
+        ignoreNonDOM: true,
+      },
     ],
     'vue-a11y/aria-props': 'error',
     'vue-a11y/aria-unsupported-elements': 'error',
@@ -25,6 +25,6 @@ module.exports = {
     'vue-a11y/no-onchange': 'error',
     'vue-a11y/no-redundant-roles': 'error',
     'vue-a11y/role-has-required-aria-props': 'error',
-    'vue-a11y/tabindex-no-positive': 'error'
-  }
+    'vue-a11y/tabindex-no-positive': 'error',
+  },
 };

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -1,5 +1,6 @@
 module.exports = {
   rules: {
+    'vue/component-definition-name-casing': 'error',
     'vue/component-name-in-template-casing': 'error',
     'vue/dot-location': 'error',
     'vue/html-self-closing': [

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -39,6 +39,7 @@ module.exports = {
     // Add with v7 of eslint-plugin-vue when it is released.
     // 'vue/no-v-model-argument': 'error',
     'vue/padding-line-between-blocks': 'error',
+    'vue/prop-name-casing': 'error',
     'vue/require-direct-export': 'error',
     'vue/require-name-property': 'error',
     'vue/valid-v-slot': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -2,6 +2,7 @@ module.exports = {
   rules: {
     'vue/component-definition-name-casing': 'error',
     'vue/component-name-in-template-casing': 'error',
+    'vue/component-tags-order': 'error',
     'vue/dot-location': 'error',
     'vue/html-self-closing': [
       'warn',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -36,6 +36,7 @@ module.exports = {
     // Add with v7 of eslint-plugin-vue when it is released.
     // 'vue/no-multiple-template-root': 'error',
     'vue/no-reserved-component-names': 'error',
+    'vue/no-static-inline-styles': 'error',
     // Add with v7 of eslint-plugin-vue when it is released.
     // 'vue/no-v-model-argument': 'error',
     'vue/padding-line-between-blocks': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -27,11 +27,17 @@ module.exports = {
     'vue/max-attributes-per-line': 'off',
     'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/no-boolean-default': 'error',
+    // Add with v7 of eslint-plugin-vue when it is released.
+    // 'vue/no-custom-modifiers-on-v-model': 'error',
     'vue/no-deprecated-slot-attribute': 'error',
     'vue/no-deprecated-slot-scope-attribute': 'error',
     'vue/no-empty-pattern': 'error',
     'vue/no-irregular-whitespace': 'error',
+    // Add with v7 of eslint-plugin-vue when it is released.
+    // 'vue/no-multiple-template-root': 'error',
     'vue/no-reserved-component-names': 'error',
+    // Add with v7 of eslint-plugin-vue when it is released.
+    // 'vue/no-v-model-argument': 'error',
     'vue/padding-line-between-blocks': 'error',
     'vue/require-direct-export': 'error',
     'vue/require-name-property': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -25,7 +25,6 @@ module.exports = {
       },
     ],
     'vue/max-attributes-per-line': 'off',
-    'vue/name-property-casing': ['error', 'kebab-case'],
     'vue/no-boolean-default': 'error',
     // Add with v7 of eslint-plugin-vue when it is released.
     // 'vue/no-custom-modifiers-on-v-model': 'error',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+    'vue/component-name-in-template-casing': 'error',
     'vue/dot-location': 'error',
     'vue/html-self-closing': [
       'warn',

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -8,19 +8,19 @@ module.exports = {
         html: {
           void: 'always',
           normal: 'always',
-          component: 'always'
+          component: 'always',
         },
         svg: 'always',
-        math: 'always'
-      }
+        math: 'always',
+      },
     ],
     'vue/keyword-spacing': 'error',
     'vue/match-component-file-name': [
       'error',
       {
         extensions: ['jsx'],
-        shouldMatchCase: false
-      }
+        shouldMatchCase: false,
+      },
     ],
     'vue/max-attributes-per-line': 'off',
     'vue/name-property-casing': ['error', 'kebab-case'],
@@ -34,6 +34,6 @@ module.exports = {
     'vue/require-direct-export': 'error',
     'vue/require-name-property': 'error',
     'vue/valid-v-slot': 'error',
-    'vue/v-slot-style': 'error'
-  }
+    'vue/v-slot-style': 'error',
+  },
 };

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -42,6 +42,7 @@ module.exports = {
     'vue/prop-name-casing': 'error',
     'vue/require-direct-export': 'error',
     'vue/require-name-property': 'error',
+    'vue/valid-v-bind-sync': 'error',
     'vue/valid-v-slot': 'error',
     'vue/v-slot-style': 'error',
   },

--- a/rules/vuex.js
+++ b/rules/vuex.js
@@ -6,9 +6,9 @@ module.exports = {
         props: true,
         ignorePropertyModificationsFor: [
           // vuex
-          'state'
-        ]
-      }
-    ]
-  }
+          'state',
+        ],
+      },
+    ],
+  },
 };

--- a/test/tests.test.js
+++ b/test/tests.test.js
@@ -38,7 +38,7 @@ describe('eslint config tests', () => {
       const expectedErrorColumnNum = 16;
       const linter = new eslint.CLIEngine({
         useEslintrc: false,
-        configFile: '.eslintrc.json'
+        configFile: '.eslintrc.json',
       });
       const errors = linter.executeOnText(code).results[0].messages;
       const error = errors[0];


### PR DESCRIPTION
Changes:

* Bump deps
* Prettier 2.x.x. changes
* Change vue/component-name-in-template-casing to default, PascalCase
* Add vue/component-definition-name-casing
* Add vue/component-tags-order
* v7 prep
* Add vue/prop-name-casing
* Add vue/valid-v-bind-sync
* Add vue/no-static-inline-styles
* Remove deprecated vue/name-property-casing