### PR TITLE
Do not run codeql on push

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,7 +1,6 @@
 name: "Code scanning"
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: '0 21 * * 4'


### PR DESCRIPTION
The codeql action has been failing for dependabot PRs and I think this should resolve it and have limited impact. Feel free to decline.
![image](https://user-images.githubusercontent.com/1946398/114615429-4f409b80-9c6b-11eb-8a16-6eda9fc979e9.png)
